### PR TITLE
fix(flaky_test): adds sleeps after subscribe+publish in some tests

### DIFF
--- a/interoperability/mqtt/clients/V311/main.py
+++ b/interoperability/mqtt/clients/V311/main.py
@@ -96,14 +96,14 @@ class Client:
 
   def connect(self, host="localhost", port=1883, newsocket=True, assertReturnCode=True,
               cleansession=True, keepalive=0, protocolName="MQTT", protocolVersion=4, username=None, password=None,
-              willFlag=False, willTopic=None, willMessage=None, willQoS=2, willRetain=False):
+              willFlag=False, willTopic=None, willMessage=None, willQoS=2, willRetain=False, socket_timeout=0.5):
     if newsocket:
       try:
         self.sock.close()
       except:
         pass
       self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-      self.sock.settimeout(.5)
+      self.sock.settimeout(socket_timeout)
       self.sock.connect((host, port))
 
     connect = MQTTV3.Connects()

--- a/interoperability/mqtt/formats/MQTTV5/MQTTV5.py
+++ b/interoperability/mqtt/formats/MQTTV5/MQTTV5.py
@@ -267,9 +267,9 @@ class VBIs:  # Variable Byte Integer
       multiplier *= 128
     return (value, bytes)
 
-def getPacket(aSocket):
+def getPacket(aSocket, socket_timeout=0.3):
   "receive the next packet"
-  aSocket.settimeout(.3)
+  aSocket.settimeout(socket_timeout)
   buf = aSocket.recv(1) # get the first byte fixed header
   if len(buf) == 0:
     return None
@@ -336,7 +336,7 @@ class FixedHeaders(object):
     return {
       "PacketType":Packets.classNames[self.PacketType],
       "DUP": self.DUP,
-      "QoS": self.QoS, 
+      "QoS": self.QoS,
       "RETAIN": self.RETAIN,
       }
 
@@ -819,7 +819,7 @@ class Connects(Packets):
       "ProtocolName": self.ProtocolName,
       "ProtocolVersion": self.ProtocolVersion,
       "CleanStart": self.CleanStart,
-      "WillFlag": self.WillFlag, 
+      "WillFlag": self.WillFlag,
       "KeepAliveTimer": self.KeepAliveTimer,
       "ClientId": self.ClientIdentifier,
       "usernameFlag": self.usernameFlag,

--- a/interoperability/test_client/V311/test_basic.py
+++ b/interoperability/test_client/V311/test_basic.py
@@ -5,6 +5,18 @@ import functools
 import time
 import pytest
 
+@pytest.fixture
+def base_socket_timeout(pytestconfig):
+    return pytestconfig.getoption('base_socket_timeout')
+
+@pytest.fixture
+def base_sleep(pytestconfig):
+    return pytestconfig.getoption('base_sleep')
+
+@pytest.fixture
+def base_wait_for(pytestconfig):
+    return pytestconfig.getoption('base_wait_for')
+
 class Callbacks(mqtt_client.Callback):
 
     def __init__(self):

--- a/interoperability/test_client/V5/test_basic.py
+++ b/interoperability/test_client/V5/test_basic.py
@@ -3,6 +3,18 @@ import pytest
 import mqtt.clients.V5 as mqtt_client, time, logging, socket, sys, getopt, traceback
 import mqtt.formats.MQTTV5 as MQTTV5
 
+@pytest.fixture
+def base_socket_timeout(pytestconfig):
+    return pytestconfig.getoption('base_socket_timeout')
+
+@pytest.fixture
+def base_sleep(pytestconfig):
+    return pytestconfig.getoption('base_sleep')
+
+@pytest.fixture
+def base_wait_for(pytestconfig):
+    return pytestconfig.getoption('base_wait_for')
+
 class Callbacks(mqtt_client.Callback):
 
   def __init__(self):
@@ -82,7 +94,7 @@ def cleanup(host, port):
         time.sleep(.1)
         curclient.disconnect()
         time.sleep(.1)
-    
+
 def cleanRetained(host, port):
   callback = Callbacks()
   curclient = mqtt_client.Client("clean retained".encode("utf-8"))

--- a/interoperability/test_client/V5/test_connect.py
+++ b/interoperability/test_client/V5/test_connect.py
@@ -68,6 +68,7 @@ def test_protocol():
   assert response.fh.PacketType == MQTTV5.PacketTypes.CONNACK
   assert response.reasonCode.value == 130
 
+@pytest.mark.rlog_flaky
 def test_clean_start():
   # [MQTT-3.1.2-4]
   connect_properties = MQTTV5.Properties(MQTTV5.PacketTypes.CONNECT)
@@ -76,10 +77,12 @@ def test_clean_start():
   assert connack.sessionPresent == False
   # [MQTT-3.1.2-5]
   aclient.terminate()
+  time.sleep(0.1)
   connack = aclient.connect(host=host, port=port, cleanstart=False, properties=connect_properties)
   assert connack.sessionPresent == True
   aclient.disconnect
   # [MQTT-3.1.2-6]
+  time.sleep(0.1)
   connack = bclient.connect(host=host, port=port, cleanstart=False)
   assert connack.sessionPresent == False
   bclient.disconnect()
@@ -570,4 +573,3 @@ def test_connect_actions():
   new_client.disconnect()
   aclient.disconnect()
   bclient.disconnect()
- 

--- a/interoperability/test_client/V5/test_connect.py
+++ b/interoperability/test_client/V5/test_connect.py
@@ -1,6 +1,10 @@
 from .test_basic import *
 import mqtt.formats.MQTTV5 as MQTTV5, mqtt.clients.V5 as mqtt_client, pytest,time
 
+# These need to be imported explicitly so that pytest sees it
+from .test_basic import base_socket_timeout, base_sleep, base_wait_for
+
+
 @pytest.fixture(scope="module", autouse=True)
 def __setUp(pytestconfig):
   global host, port
@@ -69,7 +73,7 @@ def test_protocol():
   assert response.reasonCode.value == 130
 
 @pytest.mark.rlog_flaky
-def test_clean_start():
+def test_clean_start(base_sleep):
   # [MQTT-3.1.2-4]
   connect_properties = MQTTV5.Properties(MQTTV5.PacketTypes.CONNECT)
   connect_properties.SessionExpiryInterval = 5
@@ -77,12 +81,12 @@ def test_clean_start():
   assert connack.sessionPresent == False
   # [MQTT-3.1.2-5]
   aclient.terminate()
-  time.sleep(0.1)
+  time.sleep(1 * base_sleep)
   connack = aclient.connect(host=host, port=port, cleanstart=False, properties=connect_properties)
   assert connack.sessionPresent == True
   aclient.disconnect
   # [MQTT-3.1.2-6]
-  time.sleep(0.1)
+  time.sleep(1 * base_sleep)
   connack = bclient.connect(host=host, port=port, cleanstart=False)
   assert connack.sessionPresent == False
   bclient.disconnect()

--- a/interoperability/test_client/V5/test_publish.py
+++ b/interoperability/test_client/V5/test_publish.py
@@ -1,4 +1,4 @@
-from .test_basic import * 
+from .test_basic import *
 import mqtt.formats.MQTTV5 as MQTTV5, time
 
 @pytest.fixture(scope="module", autouse=True)
@@ -6,7 +6,7 @@ def __setUp(pytestconfig):
   global host, port
   host = pytestconfig.getoption('host')
   port = int(pytestconfig.getoption('port'))
-  
+
 def test_qos():
   #[MQTT-3.3.1-4]
   aclient.connect(host=host, port=port)
@@ -14,7 +14,7 @@ def test_qos():
   publish = MQTTV5.Publishes()
   publish.fh.QoS = 3
   mqtt_client.main.sendtosocket(aclient.sock, publish.pack())
-  
+
   waitfor(callback.disconnects, 1, 3)
   assert len(callback.disconnects) == 1
   assert callback.disconnects[0]["reasonCode"].value == 130
@@ -42,7 +42,7 @@ def test_retained_message():
   assert callback.messages[0][1] == b"qos 1 retained"
   aclient.unsubscribe([topics[2]])
   waitfor(callback.unsubscribeds, 1, 3)
-  
+
   # [MQTT-3.3.1-5]
   callback.clear()
   aclient.publish(topics[2], b"qos 1 new retained", 1, retained=True)
@@ -54,7 +54,7 @@ def test_retained_message():
   assert callback.messages[0][1] == b"qos 1 new retained"
   aclient.unsubscribe([topics[2]])
   waitfor(callback.unsubscribeds, 1, 3)
-  
+
   # [MQTT-3.3.1-8]
   callback.clear()
   aclient.publish(topics[2], b"qos 1 not retained", 1, retained=False)
@@ -74,7 +74,7 @@ def test_retained_message():
   aclient.subscribe([topics[2]], [MQTTV5.SubscribeOptions(2)])
   waitfor(callback.subscribeds, 1, 3)
   waitfor(callback.messages, 1, 3)
-  assert len(callback.messages) == 0 
+  assert len(callback.messages) == 0
   aclient.disconnect()
 
 def test_retain_handling():
@@ -82,7 +82,7 @@ def test_retain_handling():
   aclient.connect(host=host, port=port, cleanstart=True)
   aclient.publish(topics[2], b"qos 1 retained", 1, retained=True)
   waitfor(callback.publisheds, 1, 3)
-  # [MQTT-3.3.1-9] 
+  # [MQTT-3.3.1-9]
   callback2.clear()
   bclient.connect(host=host, port=port, cleanstart=True)
   bclient.subscribe([topics[2]], [MQTTV5.SubscribeOptions(2,False,False,0)])
@@ -93,7 +93,7 @@ def test_retain_handling():
   assert len(callback2.messages) == 2
   bclient.disconnect()
 
-  # [MQTT-3.3.1-10] 
+  # [MQTT-3.3.1-10]
   callback2.clear()
   bclient.connect(host=host, port=port, cleanstart=True)
   bclient.subscribe([topics[2]], [MQTTV5.SubscribeOptions(2,False,False,1)])
@@ -116,13 +116,13 @@ def test_retain_handling():
   waitfor(callback.publisheds, 1, 3)
   assert len(callback.publisheds) == 1
   aclient.disconnect()
-  
+
 def test_topic():
   # [MQTT-3.3.2-1]
   # with pytest.raises(Exception):
   #   aclient.connect(host=host, port=port, cleanstart=True)
   #   aclient.publish("主题名".encode('gbk'), b"test topic", 1)
-  
+
   # [MQTT-3.3.2-2]
   aclient.connect(host=host, port=port, cleanstart=True)
   aclient.publish(wildtopics[0], b"test topic", 1)
@@ -133,6 +133,7 @@ def test_topic():
   # [MQTT-3.3.2-3]
   aclient.connect(host=host, port=port, cleanstart=True)
   aclient.subscribe([topics[0]], [MQTTV5.SubscribeOptions(2)])
+  time.sleep(0.1)
   aclient.publish(topics[0], b"test topic", 1)
   waitfor(callback.messages, 1, 3)
   aclient.disconnect()
@@ -144,6 +145,7 @@ def test_payload_format_indicator():
   publish_properties.PayloadFormatIndicator = 56
   aclient.connect(host=host, port=port, cleanstart=True)
   aclient.subscribe([topics[0]], [MQTTV5.SubscribeOptions(2)])
+  time.sleep(0.1)
   aclient.publish(topics[0], b"test_payload_format_indicator", 1, properties=publish_properties)
   waitfor(callback.messages, 1, 3)
   aclient.disconnect()
@@ -175,7 +177,7 @@ def test_message_expiry_interval():
   waitfor(callback2.messages, 4, 3)
   bclient.disconnect()
   aclient.disconnect()
-  # [MQTT-3.3.2-5] 
+  # [MQTT-3.3.2-5]
   assert len(callback2.messages) == 2
   # [MQTT-3.3.2-6]
   assert callback2.messages[0][5].MessageExpiryInterval < 6
@@ -331,7 +333,7 @@ def test_overlapping_subscriptions():
     assert hasattr(m[5], "SubscriptionIdentifier")
     assert m[5].SubscriptionIdentifier == sub_properties.SubscriptionIdentifier
 
-  
+
 def test_subscribe_identifiers():
   aclient.connect(host=host, port=port, cleanstart=True)
   sub_properties = MQTTV5.Properties(MQTTV5.PacketTypes.SUBSCRIBE)
@@ -361,7 +363,7 @@ def test_subscribe_identifiers():
   waitfor(callback2.messages, 2, 5)
   assert len(callback2.messages) == 2
   expected_subsids = set([2, 3])
-  received_subsids = set([callback2.messages[0][5].SubscriptionIdentifier[0], 
+  received_subsids = set([callback2.messages[0][5].SubscriptionIdentifier[0],
                           callback2.messages[1][5].SubscriptionIdentifier[0]])
   assert received_subsids == expected_subsids
   bclient.disconnect()

--- a/interoperability/test_client/V5/test_shared_subscribe.py
+++ b/interoperability/test_client/V5/test_shared_subscribe.py
@@ -1,4 +1,4 @@
-from .test_basic import * 
+from .test_basic import *
 import mqtt.formats.MQTTV5 as MQTTV5, time
 
 shared_sub_topic = '$share/sharename/' + topic_prefix + 'x'
@@ -13,7 +13,7 @@ def __setUp(pytestconfig):
 def test_shared_subscriptions():
   connack = aclient.connect(host=host, port=port, cleanstart=True)
   assert connack.properties.SharedSubscriptionAvailable == 1
-  aclient.subscribe([shared_sub_topic, topics[0]], [MQTTV5.SubscribeOptions(2)]*2) 
+  aclient.subscribe([shared_sub_topic, topics[0]], [MQTTV5.SubscribeOptions(2)]*2)
   waitfor(callback.subscribeds, 1, 3)
 
   ## this is ia bug
@@ -24,9 +24,9 @@ def test_shared_subscriptions():
   # waitfor(callback2.disconnects, 1, 3)
   # assert len(callback2.disconnects) == 1
   # assert callback2.disconnects[0]["reasonCode"].value == 130
-    
+
   bclient.connect(host=host, port=port, cleanstart=True)
-  bclient.subscribe([shared_sub_topic, topics[0]], [MQTTV5.SubscribeOptions(2)]*2) 
+  bclient.subscribe([shared_sub_topic, topics[0]], [MQTTV5.SubscribeOptions(2)]*2)
   waitfor(callback2.subscribeds, 1, 3)
 
   callback.clear()
@@ -64,17 +64,17 @@ def test_retain():
 
   aclient.connect(host=host, port=port, cleanstart=True)
   bclient.connect(host=host, port=port, cleanstart=True)
-  
+
   aclient.publish(shared_pub_topic, b"test_shared_subscriptions_retain", 1, retained=True)
   time.sleep(1)
-  bclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(2)]) 
+  bclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(2)])
   waitfor(callback2.messages, 1, 3)
   assert len(callback2.messages) == 0
   cleanRetained(host, port)
 
 def test_qos():
   aclient.connect(host=host, port=port, cleanstart=True)
-  aclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(2)]) 
+  aclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(2)])
   waitfor(callback.subscribeds, 1, 3)
 
   bclient.connect(host=host, port=port, cleanstart=True)
@@ -88,7 +88,7 @@ def test_qos():
   callback.clear()
 
   aclient.connect(host=host, port=port, cleanstart=True)
-  aclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(1)]) 
+  aclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(1)])
   waitfor(callback.subscribeds, 1, 3)
 
   bclient.publish(shared_pub_topic, b"test_shared_subscriptions_qos", 2)
@@ -174,7 +174,7 @@ def test_client_terminates_when_qos_eq_2():
   sock.close()
 
   bclient.connect(host=host, port=port, cleanstart=True)
-  bclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(2)]) 
+  bclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(2)])
 
   connect = MQTTV5.Connects()
   connect.ClientIdentifier = "test_shared_subscriptions"
@@ -197,8 +197,11 @@ def test_client_terminates_when_qos_eq_2():
   assert response.fh.QoS == 2
   assert response.data == b'test_shared_subscriptions_client_terminates_when_qos_eq_2'
 
+@pytest.mark.rlog_flaky
 def test_puback_filed():
   ## If a Client responds with a PUBACK or PUBREC containing a Reason Code of 0x80 or greater to a PUBLISH packet from the Server, the Server MUST discard the Application Message and not attempt to send it to any other Subscriber [MQTT-4.8.2-6].
+  callback2.clear()
+
   pubclient = mqtt_client.Client("pubclient".encode("utf-8"))
   pubclient.connect(host=host, port=port, cleanstart=True)
 
@@ -206,27 +209,29 @@ def test_puback_filed():
   connect.ClientIdentifier = "test_shared_subscriptions"
   connect.CleanStart = True
   sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-  sock.settimeout(.5)
+  sock.settimeout(.8)
   sock.connect((host, port))
   mqtt_client.main.sendtosocket(sock, connect.pack())
-  response = MQTTV5.unpackPacket(MQTTV5.getPacket(sock))
+  response = MQTTV5.unpackPacket(MQTTV5.getPacket(sock, socket_timeout=0.8))
   assert response.fh.PacketType == MQTTV5.PacketTypes.CONNACK
 
   subscribe = MQTTV5.Subscribes()
   subscribe.packetIdentifier = 2
   subscribe.data.append((shared_sub_topic, MQTTV5.SubscribeOptions(2)))
   mqtt_client.main.sendtosocket(sock, subscribe.pack())
-  response = MQTTV5.unpackPacket(MQTTV5.getPacket(sock))
+  response = MQTTV5.unpackPacket(MQTTV5.getPacket(sock, socket_timeout=0.8))
   assert response.fh.PacketType == MQTTV5.PacketTypes.SUBACK
+  time.sleep(0.2)
 
   pubclient.publish(shared_pub_topic, b"test_puback_filed", 1)
 
-  response = MQTTV5.unpackPacket(MQTTV5.getPacket(sock))
+  response = MQTTV5.unpackPacket(MQTTV5.getPacket(sock, socket_timeout=0.8))
   assert response.fh.PacketType == MQTTV5.PacketTypes.PUBLISH
   assert response.fh.QoS == 1
 
   bclient.connect(host=host, port=port, cleanstart=True)
-  bclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(2)]) 
+  bclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(2)])
+  time.sleep(0.2)
 
   puback = MQTTV5.Pubacks()
   puback.packetIdentifier = response.packetIdentifier
@@ -236,24 +241,25 @@ def test_puback_filed():
   waitfor(callback2.messages, 1, 3)
   assert len(callback2.messages) == 0
 
+@pytest.mark.rlog_flaky
 def test_overlapping_subscription():
   ##  A Client is permitted to submit a second SUBSCRIBE request to a Shared Subscription on a Session that's already subscribed to that Shared Subscription. For example, it might do this to change the Requested QoS for its subscription or because it was uncertain that the previous subscribe completed before the previous connection was closed. This does not increase the number of times that the Session is associated with the Shared Subscription, so the Session will leave the Shared Subscription on its first UNSUBSCRIBE.
   aclient.connect(host=host, port=port, cleanstart=True)
   bclient.connect(host=host, port=port, cleanstart=True)
 
-  aclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(2)]) 
-  waitfor(callback.subscribeds, 1, 3)
+  aclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(2)])
+  waitfor(callback.subscribeds, 1, 5)
   assert callback.subscribeds[0][1][0].value == 2
 
   callback.clear()
 
-  aclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(1)]) 
-  waitfor(callback.subscribeds, 1, 3)
+  aclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(1)])
+  waitfor(callback.subscribeds, 1, 5)
   assert callback.subscribeds[0][1][0].value == 1
 
   bclient.publish(shared_pub_topic, b"test_overlapping_subscription_1", 1)
-  
-  waitfor(callback.messages, 1, 3)
+
+  waitfor(callback.messages, 1, 5)
   assert callback.messages[0][1] == b'test_overlapping_subscription_1'
   assert callback.messages[0][2] == 1
 
@@ -262,7 +268,7 @@ def test_subscriptions_to_both_shared_and_non_shared():
   ## Each Shared Subscription is independent from any other. It is possible to have two Shared Subscriptions with overlapping filters. In such cases a message that matches both Shared Subscriptions will be processed separately by both of them. If a Client has a Shared Subscription and a Non‑shared Subscription and a message matches both of them, the Client will receive a copy of the message by virtue of it having the Non‑shared Subscription. A second copy of the message will be delivered to one of the subscribers to the Shared Subscription, and this could result in a second copy being sent to this Client.
   aclient.connect(host=host, port=port, cleanstart=True)
   bclient.connect(host=host, port=port, cleanstart=True)
-  
+
   aclient.subscribe([shared_pub_topic, shared_sub_topic], [MQTTV5.SubscribeOptions(2)]*2)
   waitfor(callback.subscribeds, 2, 3)
   bclient.publish(shared_pub_topic, b"test_overlapping_subscription_2", 1)

--- a/interoperability/test_client/conftest.py
+++ b/interoperability/test_client/conftest.py
@@ -5,3 +5,15 @@ def pytest_addoption(parser):
                      help='host of mqtt broker')
     parser.addoption('--port', action='store', default='1883',
                      help='port of mqtt broker')
+    parser.addoption('--base-socket-timeout', action='store', type=float,
+                     default=0.1, help='base socket timeout amount'
+                                       ' for receiving responses.'
+                                       ' unit is seconds.')
+    parser.addoption('--base-sleep', action='store', type=float,
+                     default=0.1, help='base sleep amount to be used '
+                                       ' between timing sensitive operations.'
+                                       ' unit is seconds')
+    parser.addoption('--base-wait-for', action='store', type=float,
+                     default=1.0, help='base amount to be used '
+                                       ' while waiting for callback responses.'
+                                       ' unit is seconds')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
-python_files = tests.py test_*.py 
+python_files = tests.py test_*.py
+markers =
+    rlog_flaky


### PR DESCRIPTION
Thoses tests tend to fail a lot in Functional Verification Tests (FVT)
using the RLOG DB backend in CI, due to increased latencies/jitter
between subscribing and publishing.