### PR TITLE
fix: frame_too_large flakyness

### DIFF
--- a/interoperability/test_client/V5/test_connack.py
+++ b/interoperability/test_client/V5/test_connack.py
@@ -84,22 +84,6 @@ def test_assigned_cliend_id():
   assert hasattr(connack.properties, "AssignedClientIdentifier") and connack.properties.AssignedClientIdentifier != ''
   client.disconnect()
 
-@pytest.mark.rlog_flaky
-def test_maximum_packet_size(base_wait_for, base_sleep, base_socket_timeout):
-  callback.clear()
-  # [MQTT-3.2.2-15]
-  # 1. server max packet size
-  connack = aclient.connect(host=host, port=port, cleanstart=True,
-                            socket_timeout=9 * base_socket_timeout)
-  assert hasattr(connack.properties, "MaximumPacketSize")
-  payload = b"." * (int(connack.properties.MaximumPacketSize) + 1)
-  time.sleep(2 * base_sleep)
-  aclient.publish(topics[0], payload, 0)
-  # should get back a disconnect with packet size too big
-  waitfor(callback.disconnects, 1, 9 * base_wait_for)
-  assert len(callback.disconnects) == 1
-  assert callback.disconnects[0]["reasonCode"].value == 149
-
 def test_receive_maximum():
   connect_properties = MQTTV5.Properties(MQTTV5.PacketTypes.CONNECT)
   connect_properties.ReceiveMaximum=0

--- a/interoperability/test_client/V5/test_publish.py
+++ b/interoperability/test_client/V5/test_publish.py
@@ -375,3 +375,21 @@ def test_subscribe_identifiers(base_wait_for):
                           callback2.messages[1][5].SubscriptionIdentifier[0]])
   assert received_subsids == expected_subsids
   bclient.disconnect()
+
+@pytest.mark.rlog_flaky
+def test_maximum_packet_size(base_wait_for, base_sleep, base_socket_timeout):
+  callback.clear()
+  # [MQTT-3.2.2-15]
+  # 1. server max packet size
+  myclient = mqtt_client.Client("test_maximum_packet_size")
+  myclient.registerCallback(callback)
+  connack = myclient.connect(host=host, port=port, cleanstart=True,
+                             socket_timeout=9 * base_socket_timeout)
+  assert hasattr(connack.properties, "MaximumPacketSize" )
+  payload = b"." * (int(connack.properties.MaximumPacketSize) + 1)
+  time.sleep(4 * base_sleep)
+  myclient.publish(topics[0], payload, 0)
+  # should get back a disconnect with packet size too big
+  waitfor(callback.disconnects, 1, 9 * base_wait_for)
+  assert len(callback.disconnects) == 1
+  assert callback.disconnects[0]["reasonCode"].value == 149


### PR DESCRIPTION
* the test case belongs to publish suite
* used a unique client id for better logging correlation
* increaed wait time for the pakcet close

verified locally with
```
> pytest -v interoperability/test_client/V5/test_publish.py::test_maximum_packet_size
==================================================================================================================================================== test session starts =====================================================================================================================================================
platform linux -- Python 3.8.10, pytest-6.2.3, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /mnt/code/src/paho.mqtt.testing, configfile: pytest.ini
collected 1 item

interoperability/test_client/V5/test_publish.py::test_maximum_packet_size PASSED
```