### PR TITLE
fix: fix 'Incorrect protocol name' case

### DIFF
--- a/interoperability/test_client/V311/test_connect.py
+++ b/interoperability/test_client/V311/test_connect.py
@@ -53,8 +53,8 @@ class TestConnect():
         client = mqtt_client.Client("myclientid", callback)
         with pytest.raises(Exception) as e:
             client.connect(host=host, port=port, protocolName="bad_name")
-        assert e.value.args[0] == 'connect was Connacks(DUP=False, QoS=0, Retain=False, Session present=False, ReturnCode=1)'
-
+        # According to the sepc,  If the protocol name is incorrect the Server MAY disconnect the Client
+        assert e.value.args[0] == 'connect was Connacks(DUP=False, QoS=0, Retain=False, Session present=False, ReturnCode=1)' or e.value.args[0] == 'connect failed - socket closed, no connack'
     # [MQTT-3.1.2-2] Unacceptable protocol level
     @pytest.mark.skip(strict=True, reason='Emqx defaults to V5 error handling when protocol version error occurs')
     def test_proto_level(self):


### PR DESCRIPTION
According to the sepc,  If the protocol name is incorrect the Server MAY disconnect the Client