### PR TITLE
fix: setting a non-local option to ture should get `ProtocolError`

### DIFF
--- a/interoperability/test_client/V5/test_shared_subscribe.py
+++ b/interoperability/test_client/V5/test_shared_subscribe.py
@@ -20,14 +20,13 @@ def test_shared_subscriptions():
   aclient.subscribe([shared_sub_topic, topics[0]], [MQTTV5.SubscribeOptions(2)]*2)
   waitfor(callback.subscribeds, 1, 3)
 
-  ## this is ia bug
   ## Setting a non-local option to 1 when sharing a subscription will result in a protocol error (protocol error)
   # [MQTT-3.8.3-4]
-  # bclient.connect(host=host, port=port, cleanstart=True)
-  # bclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(QoS=2, noLocal=1)])
-  # waitfor(callback2.disconnects, 1, 3)
-  # assert len(callback2.disconnects) == 1
-  # assert callback2.disconnects[0]["reasonCode"].value == 130
+  bclient.connect(host=host, port=port, cleanstart=True)
+  bclient.subscribe([shared_sub_topic], [MQTTV5.SubscribeOptions(QoS=2, noLocal=True)])
+  waitfor(callback2.disconnects, 1, 3)
+  assert len(callback2.disconnects) == 1
+  assert callback2.disconnects[0]["reasonCode"].value == 130
 
   bclient.connect(host=host, port=port, cleanstart=True)
   bclient.subscribe([shared_sub_topic, topics[0]], [MQTTV5.SubscribeOptions(2)]*2)


### PR DESCRIPTION
Related and should be merged after https://github.com/emqx/emqx/pull/10976