### PR TITLE
test: allow peer reset connection if packet too large

### DIFF
--- a/interoperability/mqtt/clients/V5/internal.py
+++ b/interoperability/mqtt/clients/V5/internal.py
@@ -169,4 +169,7 @@ class Receivers:
       if not self.stopping and sys.exc_info()[0] != socket.error:
         logger.error("call: unexpected exception %s", str(sys.exc_info()))
         traceback.print_exc()
+        # Store exception in callback if it has exceptions attribute
+        if hasattr(callback, 'exceptions'):
+          callback.exceptions.append(sys.exc_info()[:2])
     self.running = False

--- a/interoperability/test_client/V5/test_basic.py
+++ b/interoperability/test_client/V5/test_basic.py
@@ -24,6 +24,7 @@ class Callbacks(mqtt_client.Callback):
     self.subscribeds = []
     self.unsubscribeds = []
     self.disconnects = []
+    self.exceptions = []
 
   def __str__(self):
      return str(self.messages) + str(self.messagedicts) + str(self.publisheds) + \

--- a/interoperability/test_client/V5/test_publish.py
+++ b/interoperability/test_client/V5/test_publish.py
@@ -1,5 +1,5 @@
 from .test_basic import *
-import mqtt.formats.MQTTV5 as MQTTV5, time
+import mqtt.formats.MQTTV5 as MQTTV5, time, errno
 
 # These need to be imported explicitly so that pytest sees it
 from .test_basic import base_socket_timeout, base_sleep, base_wait_for
@@ -389,7 +389,16 @@ def test_maximum_packet_size(base_wait_for, base_sleep, base_socket_timeout):
   payload = b"." * (int(connack.properties.MaximumPacketSize) + 1)
   time.sleep(4 * base_sleep)
   myclient.publish(topics[0], payload, 0)
-  # should get back a disconnect with packet size too big
-  waitfor(callback.disconnects, 1, 9 * base_wait_for)
-  assert len(callback.disconnects) == 1
-  assert callback.disconnects[0]["reasonCode"].value == 149
+  try:
+    # case 1: broker sends proper DISCONNECT
+    waitfor(callback.disconnects, 1, 9 * base_wait_for)
+    assert len(callback.disconnects) == 1
+    assert callback.disconnects[0]["reasonCode"].value == 149
+  except AssertionError:
+    # case 2: broker just closed TCP
+    # allow it as valid too
+    assert not callback.disconnects
+    assert callback.exceptions  # make sure something got logged
+    exc_type, exc_val = callback.exceptions[-1]
+    assert exc_type is ConnectionResetError
+    assert exc_val.errno == errno.ECONNRESET


### PR DESCRIPTION
Allow broker to close socket (without sending DISCONNECT) if packet is too large.

This allows the MQTT message frame-parse (Type+RemainingBytes+Body, no body decoding) to be moved to a lower level stack which only knows the framing and max-packet-size limit.
Since the lower stack is not MQTT aware, it cannot send DISCONNECT, so it closes socket.