### PR TITLE
test: accept Malformed Packet (129) for QoS=3 / DUP=1 PUBLISH

### DIFF
--- a/interoperability/test_client/V5/test_publish.py
+++ b/interoperability/test_client/V5/test_publish.py
@@ -22,7 +22,12 @@ def test_qos(base_wait_for):
 
   waitfor(callback.disconnects, 1, 3 * base_wait_for)
   assert len(callback.disconnects) == 1
-  assert callback.disconnects[0]["reasonCode"].value == 130
+  # Accept both Malformed Packet (0x81 = 129) and Protocol Error (0x82 = 130).
+  # MQTT-3.3.1-4 says the malformed QoS bits make this a Malformed Packet, but
+  # brokers running with a lenient parser may surface it as Protocol Error
+  # after deeper validation. EMQX returns 129 with strict_mode = true (the
+  # release-6.3 default) and 130 with strict_mode = false.
+  assert callback.disconnects[0]["reasonCode"].value in (129, 130)
 
 def test_dup():
   aclient.connect(host=host, port=port)
@@ -33,7 +38,10 @@ def test_dup():
 
   waitfor(callback.disconnects, 1, 3)
   assert len(callback.disconnects) == 1
-  assert callback.disconnects[0]["reasonCode"].value == 130
+  # See test_qos: 129 (Malformed Packet) when the broker's parser is strict,
+  # 130 (Protocol Error) when it accepts the malformed header and rejects
+  # later in the publish-handling layer.
+  assert callback.disconnects[0]["reasonCode"].value in (129, 130)
 
 def test_retained_message():
   callback.clear()


### PR DESCRIPTION
Brokers with strict frame parsing (e.g. EMQX 6.3+ with `mqtt.strict_mode = true`, which is the new default) reject malformed QoS bits at parse time and disconnect with reason code 0x81 (Malformed Packet), per MQTT-3.3.1-4.

Brokers running with a lenient parser may decode the packet and reject it later in publish handling with reason code 0x82 (Protocol Error).

Both behaviors are observed across EMQX configurations, so accept either.